### PR TITLE
Add markdown streaming endpoint and reader UI

### DIFF
--- a/src/history_util.py
+++ b/src/history_util.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import json
 import logging
 import os
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from typing import Any
 
 HISTORY_DIR = os.path.join(os.path.dirname(__file__), "../cache/history")
@@ -19,7 +19,7 @@ LOGGER = logging.getLogger(__name__)
 
 
 def _now_iso() -> str:
-    return datetime.now(timezone.utc).replace(tzinfo=None).isoformat(timespec="seconds")
+    return datetime.now(UTC).replace(tzinfo=None).isoformat(timespec="seconds")
 
 
 def ensure_history_dir() -> None:

--- a/templates/bookshelf.html
+++ b/templates/bookshelf.html
@@ -182,36 +182,39 @@
 
 			// 削除ボタン処理
 			for (const btn of document.querySelectorAll('.delete-btn')) {
-				btn.addEventListener('click', async function () {
-					if (!confirm('本当に削除しますか？')) return
-					const bookId = this.getAttribute('data-book-id')
-					const res = await fetch('/delete_epub', {
-						method: 'POST',
-						headers: { 'Content-Type': 'application/json' },
-						body: JSON.stringify({ book_id: bookId }),
-					})
-					if (res.ok) {
-						window.location.reload()
-					} else {
-						alert('削除に失敗しました')
-					}
-				})
-			}
+                                btn.addEventListener('click', async function (e) {
+                                        e.stopPropagation()
+                                        if (!confirm('本当に削除しますか？')) return
+                                        const bookId = this.getAttribute('data-book-id')
+                                        const res = await fetch('/delete_epub', {
+                                                method: 'POST',
+                                                headers: {
+                                                        'Content-Type':
+                                                                'application/json',
+                                                },
+                                                body: JSON.stringify({
+                                                        book_id: bookId,
+                                                }),
+                                        })
+                                        if (res.ok) {
+                                                window.location.reload()
+                                        } else {
+                                                alert('削除に失敗しました')
+                                        }
+                                })
+                        }
 
-			// 本全体クリックでダウンロード
-			for (const item of document.querySelectorAll('.book-item')) {
-				item.addEventListener('click', function (e) {
-					// 削除ボタン押下時は無視
-					if (e.target.closest('.delete-btn')) return
-					const bookId = this.getAttribute('data-book-id')
-					const a = document.createElement('a')
-					a.href = `/download_epub/${encodeURIComponent(bookId)}`
-					a.download = bookId
-					document.body.appendChild(a)
-					a.click()
-					document.body.removeChild(a)
-				})
-			}
+                        // 本をクリックしてリーダーを表示
+                        for (const item of document.querySelectorAll('.book-item')) {
+                                item.addEventListener('click', function () {
+                                        const bid = this.getAttribute('data-book-id')
+                                        const url =
+                                                '/reader?book_id=' +
+                                                encodeURIComponent(bid)
+                                        window.location.href = url
+                                })
+                        }
+                        // ダウンロードは個別のボタンで対応
 		</script>
 	</body>
 </html>

--- a/templates/reader.html
+++ b/templates/reader.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+    <meta charset="UTF-8" />
+    <title>リーダー - EPUB LLM</title>
+    <link rel="stylesheet" href="/static/style.css" />
+    <style>
+        body {
+            background: #15202b;
+            color: #d9d9d9;
+        }
+        .reader-container {
+            max-width: 800px;
+            margin: 40px auto;
+            line-height: 1.6;
+        }
+        .chunk {
+            white-space: pre-wrap;
+            padding: 8px;
+            border-bottom: 1px solid #22303c;
+        }
+        .highlight {
+            background: #fff176;
+            color: #000;
+        }
+    </style>
+</head>
+<body>
+    {% include 'partials/header.html' %}
+    <div id="content" class="reader-container"></div>
+    <script>
+        const params = new URLSearchParams(window.location.search);
+        const bookId = params.get('book_id');
+        async function load() {
+            const res = await fetch(
+                `/book/${encodeURIComponent(bookId)}/markdown_stream`
+            );
+            const reader = res.body.getReader();
+            const decoder = new TextDecoder();
+            let buf = '';
+            while (true) {
+                const { value, done } = await reader.read();
+                if (done) break;
+                buf += decoder.decode(value, { stream: true });
+                const lines = buf.split('\n');
+                buf = lines.pop();
+                for (const line of lines) {
+                    if (!line.trim()) continue;
+                    const data = JSON.parse(line);
+                    const pre = document.createElement('pre');
+                    pre.id = `chunk-${data.chunk_id}`;
+                    pre.className = 'chunk';
+                    pre.textContent = data.text;
+                    document.getElementById('content').appendChild(pre);
+                }
+            }
+            if (buf.trim()) {
+                const data = JSON.parse(buf);
+                const pre = document.createElement('pre');
+                pre.id = `chunk-${data.chunk_id}`;
+                pre.className = 'chunk';
+                pre.textContent = data.text;
+                document.getElementById('content').appendChild(pre);
+            }
+            const cid = params.get('chunk_id');
+            if (cid) highlightChunk(cid);
+        }
+        function highlightChunk(cid) {
+            const el = document.getElementById(`chunk-${cid}`);
+            if (el) {
+                el.classList.add('highlight');
+                el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            }
+        }
+        window.highlightChunk = highlightChunk;
+        load();
+    </script>
+</body>
+</html>

--- a/test/test_markdown_stream_api.py
+++ b/test/test_markdown_stream_api.py
@@ -1,0 +1,32 @@
+import json
+import os
+import tempfile
+
+from fastapi.testclient import TestClient
+
+import src.app as app_module
+
+
+def test_markdown_stream_endpoint(monkeypatch):
+    with tempfile.TemporaryDirectory() as tmpdir:
+        epub_dir = os.path.join(tmpdir, "epub")
+        cache_dir = os.path.join(tmpdir, "cache")
+        os.makedirs(epub_dir)
+        os.makedirs(cache_dir)
+        open(os.path.join(epub_dir, "sample.epub"), "wb").close()
+
+        monkeypatch.setattr(app_module, "EPUB_DIR", epub_dir)
+        monkeypatch.setattr(app_module, "CACHE_DIR", cache_dir)
+
+        def fake_stream(epub_path, cache_path, max_chars=800):
+            yield {"chunk_id": 0, "text": "hello"}
+            yield {"chunk_id": 1, "text": "world"}
+
+        monkeypatch.setattr(app_module, "stream_epub_markdown", fake_stream)
+
+        client = TestClient(app_module.app)
+        resp = client.get("/book/sample.epub/markdown_stream")
+        assert resp.status_code == 200
+        lines = [json.loads(line) for line in resp.text.strip().split("\n")]
+        assert lines[0]["chunk_id"] == 0
+        assert lines[1]["text"] == "world"


### PR DESCRIPTION
## Summary
- stream book content as NDJSON markdown chunks with chunk IDs
- add reader page that highlights chunks by `chunk_id` and link from bookshelf
- add test for markdown stream API and fix history utilities to use `datetime.UTC`

## Testing
- `black src`
- `ruff format .`
- `ruff check .`
- `flake8 src` *(fails: command not found)*
- `pylint src` *(fails: command not found)*
- `mypy src`
- `pytest -q` *(fails: missing EPUB samples and MLX server)*
- `pytest test/test_markdown_stream_api.py -q`


------
https://chatgpt.com/codex/tasks/task_e_689feace5f0c833085e21549d6c1f716